### PR TITLE
Add cli flag `--keyring-does-not-prompt`.

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -266,6 +266,23 @@ no_input: Callable[..., Option] = partial(
     help="Disable prompting for input.",
 )
 
+keyring_does_not_prompt: Callable[..., Option] = partial(
+    Option,
+    # Promise keyring is configured with a backend which does not prompt
+    "--keyring-does-not-prompt",
+    dest="keyring_does_not_prompt",
+    action="store_true",
+    default=False,
+    help=(
+        "Useful when pip is used indirectly by tools, such as pipx, which pass"
+        " --no-input. Use this to promise keyring is configured with a backend"
+        " which does not prompt. It is recommended to configure this via"
+        " PIP_KEYRING_DOES_NOT_PROMPT or via a config file. Setting this to"
+        " true with an incompatible keyring backend can cause the process to"
+        " hang indefinitely."
+    ),
+)
+
 proxy: Callable[..., Option] = partial(
     Option,
     "--proxy",
@@ -999,6 +1016,7 @@ general_group: Dict[str, Any] = {
         quiet,
         log,
         no_input,
+        keyring_does_not_prompt,
         proxy,
         retries,
         timeout,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -116,6 +116,9 @@ class SessionCommandMixin(CommandContextMixIn):
 
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input
+        # Determine if the user promises to have configured keyring with a
+        # backend that does not prompt
+        session.auth.prompting_keyring = not options.keyring_does_not_prompt
 
         return session
 


### PR DESCRIPTION
Currently, Pip is conservative and does not query keyring at all when `--no-input` is used because the keyring might require user interaction such as prompting the user on the console.

This commit adds a flag to pinky swear that the configured keyring backend does not require any user interaction. It defaults to `False`, making this opt-in behaviour.

Tools such as Pipx and Pipenv use Pip and have their own progress indicator that hides output from the subprocess Pip runs in. They should pass `--no-input` in my opinion, but Pip should provide some mechanism to still query the keyring in that case. Just not by default. So here we are.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
