### PR TITLE
Add cli flag `--keyring-does-not-prompt`.

### DIFF
--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -74,6 +74,25 @@ $ echo "your-password" | keyring set pypi.company.com your-username
 $ pip install your-package --index-url https://pypi.company.com/
 ```
 
+Pip does not query `keyring` for credentials when `--no-input` is used unless
+`--keyring-does-not-prompt` is used as well. `keyring` backends might not
+require any user interaction at all, they might prompt for more information on
+the console, or they could do things like trigger a security notification on a
+mobile device which needs to be approved. That is why Pip has to be
+conservative and users should be confident their configured backend requires no
+user input.
+Tools such as Pipx and Pipenv which either show a fancy progress indicator that
+hides output from the Pip subprocess, or pass `--no-input` to the Pip
+subprocess (or do both) are a situation where you will want to do some variant
+of the following since it does not require support from the tool:
+
+```bash
+# possibly with --user, --global or --site
+$ pip config set global.keyring-does-not-prompt true
+# or
+$ export PIP_KEYRING_DOES_NOT_PROMPT=1
+```
+
 Note that `keyring` (the Python package) needs to be installed separately from
 pip. This can create a bootstrapping issue if you need the credentials stored in
 the keyring to download and install keyring.

--- a/news/11020.feature.rst
+++ b/news/11020.feature.rst
@@ -1,0 +1,1 @@
+Add ``--keyring-does-not-prompt`` flag which allows ``keyring`` lookups in combination with ``--no-input``. See the Authentication page in the documentation for more info.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -261,6 +261,23 @@ no_input: Callable[..., Option] = partial(
     help="Disable prompting for input.",
 )
 
+keyring_does_not_prompt: Callable[..., Option] = partial(
+    Option,
+    # Promise keyring is configured with a backend which does not prompt
+    "--keyring-does-not-prompt",
+    dest="keyring_does_not_prompt",
+    action="store_true",
+    default=False,
+    help=(
+        "Useful when pip is used indirectly by tools, such as pipx, which pass"
+        " --no-input. Use this to promise keyring is configured with a backend"
+        " which does not prompt. It is recommended to configure this via"
+        " PIP_KEYRING_DOES_NOT_PROMPT or via a config file. Setting this to"
+        " true with an incompatible keyring backend can cause the process to"
+        " hang indefinitely."
+    ),
+)
+
 proxy: Callable[..., Option] = partial(
     Option,
     "--proxy",
@@ -993,6 +1010,7 @@ general_group: Dict[str, Any] = {
         quiet,
         log,
         no_input,
+        keyring_does_not_prompt,
         proxy,
         retries,
         timeout,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -116,6 +116,9 @@ class SessionCommandMixin(CommandContextMixIn):
 
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input
+        # Determine if the user promises to have configured keyring with a
+        # backend that does not prompt
+        session.auth.prompting_keyring = not options.keyring_does_not_prompt
 
         return session
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -72,10 +72,14 @@ def get_keyring_auth(url: Optional[str], username: Optional[str]) -> Optional[Au
 
 class MultiDomainBasicAuth(AuthBase):
     def __init__(
-        self, prompting: bool = True, index_urls: Optional[List[str]] = None
+        self,
+        prompting: bool = True,
+        index_urls: Optional[List[str]] = None,
+        prompting_keyring: bool = True,
     ) -> None:
         self.prompting = prompting
         self.index_urls = index_urls
+        self.prompting_keyring = prompting_keyring
         self.passwords: Dict[str, AuthInfo] = {}
         # When the user is prompted to enter credentials and keyring is
         # available, we will offer to save them. If the user accepts,
@@ -231,7 +235,7 @@ class MultiDomainBasicAuth(AuthBase):
     def _prompt_for_password(
         self, netloc: str
     ) -> Tuple[Optional[str], Optional[str], bool]:
-        username = ask_input(f"User for {netloc}: ")
+        username = ask_input(f"User for {netloc}: ") if self.prompting else None
         if not username:
             return None, None, False
         auth = get_keyring_auth(netloc, username)
@@ -242,7 +246,7 @@ class MultiDomainBasicAuth(AuthBase):
 
     # Factored out to allow for easy patching in tests
     def _should_save_password_to_keyring(self) -> bool:
-        if not keyring:
+        if not self.prompting or not keyring:
             return False
         return ask("Save credentials to keyring [y/N]: ", ["y", "n"]) == "y"
 
@@ -252,18 +256,24 @@ class MultiDomainBasicAuth(AuthBase):
         if resp.status_code != 401:
             return resp
 
+        username, password = None, None
+
+        # Query the keyring for credentials:
+        # Keyring backends might prompt the user interactively in some way.
+        # Therefor we only query keyring when --no-input is used if the user
+        # promised the configured backend will not prompt them.
+        if self.prompting or not self.prompting_keyring:
+            username, password = self._get_new_credentials(
+                resp.url,
+                allow_netrc=True,
+                allow_keyring=True,
+            )
+
         # We are not able to prompt the user so simply return the response
-        if not self.prompting:
+        if not self.prompting and not username and not password:
             return resp
 
         parsed = urllib.parse.urlparse(resp.url)
-
-        # Query the keyring for credentials:
-        username, password = self._get_new_credentials(
-            resp.url,
-            allow_netrc=True,
-            allow_keyring=True,
-        )
 
         # Prompt the user for a new username and password
         save = False

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -353,25 +353,41 @@ def test_do_not_prompt_for_authentication(
     assert "ERROR: HTTP error 401" in result.stderr
 
 
-@pytest.fixture(params=(True, False), ids=("auth_needed", "auth_not_needed"))
+@pytest.fixture(params=(True, False))
 def auth_needed(request: pytest.FixtureRequest) -> bool:
     return request.param  # type: ignore[attr-defined]
 
 
 @pytest.fixture(
     params=(
-        False,
-        True,
+        (False, False, False),
+        (False, True, False),
+        (True, True, False),
+        (True, False, True),
     ),
-    ids=("default", "no_input"),
+    ids=(
+        "default-default",
+        "default-keyring_does_not_prompt",
+        "no_input-keyring_does_not_prompt",
+        "no_input-default",
+    ),
 )
-def flags(request: pytest.FixtureRequest) -> typing.List[str]:
-    no_input = request.param  # type: ignore[attr-defined]
+def flags(request: pytest.FixtureRequest, auth_needed: bool) -> typing.List[str]:
+    (
+        no_input,
+        keyring_does_not_prompt,
+        xfail,
+    ) = request.param  # type: ignore[attr-defined]
 
     flags = []
     if no_input:
         flags.append("--no-input")
-
+    if keyring_does_not_prompt:
+        flags.append(
+            "--keyring-does-not-prompt",
+        )
+    if auth_needed and xfail:
+        request.applymarker(pytest.mark.xfail())
     return flags
 
 


### PR DESCRIPTION
Currently, Pip is conservative and does not query keyring at all when `--no-input` is used because the keyring might require user interaction such as prompting the user on the console.

This commit adds a flag to pinky swear that the configured keyring backend does not require any user interaction. It defaults to `False`, making this opt-in behaviour.

Tools such as Pipx and Pipenv use Pip and have their own progress indicator that hides output from the subprocess Pip runs in. They should pass `--no-input` in my opinion, but Pip should provide some mechanism to still query the keyring in that case. Just not by default. So here we are.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
